### PR TITLE
Updated EpsilonEAG plugins to v0.0.8 to get .eag extension working

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,9 +1,12 @@
 vscode:
   extensions:
-    - grammarcraft.epsilon-eag-dark-theme@0.0.1:ugoZ5mIyXQLxd7hb6aaErA==
-    - grammarcraft.epsilon-eag-light-theme@0.0.1:FH8VQ4YnIwg5BGgeKR+IEw==
-    - grammarcraft.epsilon-eag@0.0.1:FuXpmRvJG3jcY6+VytasEQ==
     - webfreak.code-d@0.22.0:K65wBqeoqTvGoea7XwBc+A==
+
+    - grammarcraft.epsilon-eag@0.0.8:9zTVLwpsuuFv9Fk2o2Mu/g==
+
+    - grammarcraft.epsilon-eag-light-theme@0.0.8:5z3BIl0S3hl/HGLYCRtnkw==
+
+    - grammarcraft.epsilon-eag-dark-theme@0.0.8:eOg01Ya9U3S14AzEi1JcSg==
 
 image:
   file: .gitpod.Dockerfile


### PR DESCRIPTION
With this extensions version the EpsilonEAG language plugin and the associated color themes work for .eag extension too. 