### PR TITLE
Corrects processing of anonymous nonterminals for the SOAG evaluator generator

### DIFF
--- a/example/count4b.eag
+++ b/example/count4b.eag
@@ -1,0 +1,26 @@
+! Same as count4.eag but w/o EBNF operators
+
+N = "i" N | .
+
+Z* = Z "0" | Z "1" | Z "2" | Z "3" | Z "4" | Z "5" | Z "6" | Z "7" | Z "8" | Z "9" |  .
+
+Sb: <+Z: Z> A<N, N, Z>.
+
+! This is the original rule from count4.eag
+!A: { <+ "i" N: N, - "i" N1: N, + Z2: Z> 'a' INC<Z1, Z2> <N, N1, Z1> } <+ : N, - : N, + "0": Z>.
+
+A<+ "i" N: N, - "i" N1: N, + Z2: Z>: 'a' INC<Z1, Z2> A<N, N1, Z1>.
+A<+ : N, - : N, + "0": Z>:.
+
+INC:
+<- Z "0": Z, + Z "1": Z> |
+<- Z "1": Z, + Z "2": Z> |
+<- Z "2": Z, + Z "3": Z> |
+<- Z "3": Z, + Z "4": Z> |
+<- Z "4": Z, + Z "5": Z> |
+<- Z "5": Z, + Z "6": Z> |
+<- Z "6": Z, + Z "7": Z> |
+<- Z "7": Z, + Z "8": Z> |
+<- Z "8": Z, + Z "9": Z> |
+<- Z "9": Z, + Z1 "0": Z> INC<Z, Z1> |
+<- : Z, + "1": Z>.

--- a/src/epsilon.d
+++ b/src/epsilon.d
@@ -146,6 +146,7 @@ void compile(TextIn textIn, bool sweep, bool soag)
             import SOAGProtocol = soag.eSOAGProtocol;
 
             SOAGProtocol.WriteRulesL4;
+            SOAGProtocol.WriteSyms;
         }
         ELL1Gen.GenerateParser;
         success = true;

--- a/src/soag/eSOAGOptimizer.d
+++ b/src/soag/eSOAGOptimizer.d
@@ -561,25 +561,28 @@ void Optimize()
     StackVar = firstStackVar - 1;
     for (S = SOAG.firstSym; S < SOAG.NextSym; ++S)
     {
-        for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
+        if (Sets.In(EAG.All, S))
         {
-            A = AP - SOAG.Sym[S].AffPos.Beg;
-            if (!Sets.In(EAG.Pred, S) || SOAG.IsSynthesized(S, A))
+            for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
             {
-                disjoint = true;
-                admissible = true;
-                InitVDSandVS(S, A);
-                CompleteInitVDS;
-                CheckStorageType(S, A);
-                if (disjoint)
+                A = AP - SOAG.Sym[S].AffPos.Beg;
+                if (!Sets.In(EAG.Pred, S) || SOAG.IsSynthesized(S, A))
                 {
-                    ++GlobalVar;
-                    SOAG.StorageName[AP] = -GlobalVar;
-                }
-                else if (admissible)
-                {
-                    ++StackVar;
-                    SOAG.StorageName[AP] = StackVar;
+                    disjoint = true;
+                    admissible = true;
+                    InitVDSandVS(S, A);
+                    CompleteInitVDS;
+                    CheckStorageType(S, A);
+                    if (disjoint)
+                    {
+                        ++GlobalVar;
+                        SOAG.StorageName[AP] = -GlobalVar;
+                    }
+                    else if (admissible)
+                    {
+                        ++StackVar;
+                        SOAG.StorageName[AP] = StackVar;
+                    }
                 }
             }
         }

--- a/src/soag/eSOAGProtocol.d
+++ b/src/soag/eSOAGProtocol.d
@@ -435,12 +435,12 @@ void WriteAffPos(int SymInd)
 void WriteSym(int S)
 {
     Out.write("Symbol ");
-    Out.write(EAG.HNontRepr(SOAG.SymOcc[SOAG.Sym[S].FirstOcc].SymInd));
-    Out.write(": \nFirstOcc: ");
+    Out.write(EAG.HNontRepr(S));
+    Out.write(": \n  FirstOcc: ");
     Out.write(SOAG.Sym[S].FirstOcc);
     Out.writeln;
     WriteAffPos(S);
-    Out.write("MaxPart: ");
+    Out.write("  MaxPart: ");
     Out.write(SOAG.Sym[S].MaxPart);
     Out.writeln;
     Out.flush;

--- a/src/soag/eSOAGVisitSeq.d
+++ b/src/soag/eSOAGVisitSeq.d
@@ -32,6 +32,7 @@ void ComputeVisitNo()
         for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
         {
             PartNum = DIV(SOAG.PartNum[AP] + 1, 2).to!int;
+            // !!!! Hier scheint der Fehler zu sein PartNum darf für Anonyme Nichterminals nicht berechnet werden! S muss in EAG.All sein!
             SOAG.PartNum[AP] = MaxPart - PartNum + 1;
         }
     }

--- a/src/soag/eSOAGVisitSeq.d
+++ b/src/soag/eSOAGVisitSeq.d
@@ -27,13 +27,16 @@ void ComputeVisitNo()
     int PartNum;
     for (S = SOAG.firstSym; S <= SOAG.NextSym - 1; ++S)
     {
-        MaxPart = DIV(SOAG.Sym[S].MaxPart + 1, 2).to!int;
-        SOAG.Sym[S].MaxPart = MaxPart;
-        for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
+        if (Sets.In(EAG.All, S))
         {
-            PartNum = DIV(SOAG.PartNum[AP] + 1, 2).to!int;
-            // !!!! Hier scheint der Fehler zu sein PartNum darf für Anonyme Nichterminals nicht berechnet werden! S muss in EAG.All sein!
-            SOAG.PartNum[AP] = MaxPart - PartNum + 1;
+            MaxPart = DIV(SOAG.Sym[S].MaxPart + 1, 2).to!int;
+            SOAG.Sym[S].MaxPart = MaxPart;
+            for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
+            {
+                PartNum = DIV(SOAG.PartNum[AP] + 1, 2).to!int;
+                // !!!! Hier scheint der Fehler zu sein PartNum darf für Anonyme Nichterminals nicht berechnet werden! S muss in EAG.All sein!
+                SOAG.PartNum[AP] = MaxPart - PartNum + 1;
+            }
         }
     }
 }

--- a/src/soag/eSOAGVisitSeq.d
+++ b/src/soag/eSOAGVisitSeq.d
@@ -34,7 +34,6 @@ void ComputeVisitNo()
             for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
             {
                 PartNum = DIV(SOAG.PartNum[AP] + 1, 2).to!int;
-                // !!!! Hier scheint der Fehler zu sein PartNum darf für Anonyme Nichterminals nicht berechnet werden! S muss in EAG.All sein!
                 SOAG.PartNum[AP] = MaxPart - PartNum + 1;
             }
         }

--- a/test/soag.d
+++ b/test/soag.d
@@ -38,9 +38,7 @@ unittest
     run("./epsilon --soag --space example/w-w.eag")
         .shouldMatch("Grammar is SOEAG");
     run("echo a b a b c a b a b | ./S")
-        .shouldMatch("^a b a b $")
-        .assertThrown!AssertError;
-    writeln("    FAILED");
+        .shouldMatch("^a b a b $");
 }
 
 @("compile w-w-soag.eag as SOAG and run compiler")
@@ -94,9 +92,7 @@ unittest
     run("./epsilon example/count4.eag")
         .shouldMatch("Grammar is SOEAG");
     run("echo a a a | ./S")
-        .shouldMatch("^3$")
-        .assertThrown!AssertError;
-    writeln("    FAILED");
+        .shouldMatch("^3$");
 }
 
 @("compile count5.eag as SOAG and run compiler")


### PR DESCRIPTION
- logging of anonymous nonterminals by SOAGProtocol.d corrected; was treated wrong as real nonterminals, in fact, they are not in use anymore at all
- added symbol logging at "-v" SOAG generation
- corrected the main issue by filtering anonymous nonterminals out during processing of symbols  
- 2 tests run successfully now - adapted accordingly