### PR TITLE
Redo fixes on version branch 0.2.1

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -12,6 +12,12 @@
             "targetType": "executable"
         },
         {
+            "name": "unittest",
+			"dependencies": {
+				"silly": "~>1.0.2"
+			}
+        },
+        {
             "name": "example",
             "sourcePaths": ["test"],
             "importPaths": ["test"],

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,6 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"silly": "1.0.2"
+	}
+}

--- a/src/soag/eASets.d
+++ b/src/soag/eASets.d
@@ -90,6 +90,7 @@ void Insert(ref ASet S, int Elem)
                 }
                 S.List.Elem[Elem] = Elem;
             }
+            // else same element already in the set
         }
         else
         {
@@ -108,6 +109,7 @@ void Insert(ref ASet S, int Elem)
                     S.List.Elem[Elem] = S.List.Last;
                 }
             }
+            // else same element already in the set
         }
     }
     else
@@ -122,43 +124,56 @@ void Insert(ref ASet S, int Elem)
  * SEM: löscht Element aus der Menge
  * SEF: -
  */
-void Delete(ref ASet S, int Elem)
+void Delete(ref ASet S, int e)
 {
-    int Last;
-    if (Elem <= S.Max)
+    if (e <= S.Max)
     {
-        if (Elem <= S.List.Last)
+        int last = S.List.Last;
+        if (e <= last)
         {
-            if (S.List.Elem[Elem] == Elem)
+            if (S.List.Elem[e] == e)
             {
-                if (Elem == S.List.Last)
+                if (e == last)
                 {
-                    S.List.Elem[S.List.Last] = noelem;
+                    S.List.Elem[last] = noelem;
                 }
-                else
+                else // e < last
                 {
-                    S.List.Elem[Elem] = S.List.Elem[S.List.Last];
-                    S.List.Elem[S.List.Last] = Elem;
+                    if (S.List.Elem[last] == last) 
+                    {
+                        S.List.Elem[e] = last;
+                        S.List.Elem[last] = e;
+                    }
+                    else 
+                    { 
+                        S.List.Elem[e] = S.List.Elem[last];
+                        S.List.Elem[S.List.Elem[last]] = e;
+                        S.List.Elem[last] = noelem;  
+                    }
                 }
                 --S.List.Last;
             }
+            // else element already not in the set
         }
-        else
+        else // e > last
         {
-            if (S.List.Elem[Elem] > noelem)
+            if (S.List.Elem[e] > noelem)
             {
-                if (S.List.Elem[Elem] == S.List.Last)
+                if (S.List.Elem[last] == last)
                 {
-                    S.List.Elem[S.List.Last] = noelem;
+                    S.List.Elem[S.List.Elem[e]] = last;
+                    S.List.Elem[last] = S.List.Elem[e];
                 }
-                else
+                else 
                 {
-                    S.List.Elem[S.List.Elem[Elem]] = S.List.Last;
-                    S.List.Elem[S.List.Last] = S.List.Elem[Elem];
+                    S.List.Elem[S.List.Elem[e]] = S.List.Elem[last];
+                    S.List.Elem[S.List.Elem[last]] = S.List.Elem[e];
+                    S.List.Elem[last] = noelem;
                 }
-                S.List.Elem[Elem] = noelem;
+                S.List.Elem[e] = noelem;
                 --S.List.Last;
             }
+            // else element already not in the set
         }
     }
     else
@@ -182,5 +197,258 @@ bool In(ASet S, int Elem)
     else
     {
         return S.List.Elem[Elem] == Elem;
+    }
+}
+
+@("validate inserting 0 to reset set")
+unittest
+{
+    int j;
+    ASet set;
+    New(set, 10);
+    for(j = firstIndex; j < 10; ++j)
+        Insert(set, j);
+    Reset(set);
+    Insert(set, 0);
+    assert(IsEmpty(set)==false);
+}
+
+@("reproduce set deletion error in single-sweep.eag computation")
+unittest
+{
+    ASet set1, set2;
+    New(set1, 3);
+    
+    Insert(set1, 0);
+    Insert(set1, 2);
+
+    Delete(set1, 2);
+    Delete(set1, 0);
+
+    assert(IsEmpty(set1)==true);
+    Insert(set1, 0);
+    
+    assert(IsEmpty(set1)==false);
+
+    New(set2, 3);
+    
+    Insert(set2, 0);
+    Insert(set2, 2);
+
+    // see above, only order of deletion is reverted here, but it fails
+    Delete(set2, 0);
+    Delete(set2, 2);
+
+    Insert(set2, 0);
+    
+    assert(IsEmpty(set2)==false);
+
+}
+
+private void printSet(string setName, ASet set) {
+    import std;
+    writeln(setName, ", last: ", set.List.Last);
+    for(int j = firstIndex; j <= set.Max; ++j)
+        write(set.List.Elem[j], ",");
+    writeln;
+
+}
+
+@("Delete: Given {0,1,2} as [0,1,2] with last=2, delete 0 must result in {2,1} as [2,1,0]")
+unittest
+{
+    ASet set;
+    New(set, 2);
+    Insert(set, 0);
+    Insert(set, 1);
+    Insert(set, 2);
+
+    Delete(set, 0);
+    
+    assert(In(set, 0) == false);
+    assert(In(set, 1) == true);
+    assert(In(set, 2) == true);
+
+    assert(set.List.Elem[0] == 2);
+    assert(set.List.Elem[1] == 1);
+}
+
+@("Delete: Given {0,1,3} as [0,1,3,2] with last=2, delete 0 must result in {3,1} as [3,1,-1,0]")
+unittest
+{
+    ASet set;
+    New(set, 3);
+    Insert(set, 0);
+    Insert(set, 1);
+    Insert(set, 3);
+
+    Delete(set, 0);
+    
+    assert(In(set, 0) == false);
+    assert(In(set, 1) == true);
+    assert(In(set, 2) == false);
+    assert(In(set, 3) == true);
+
+    assert(set.List.Elem[0] == 3);
+    assert(set.List.Elem[1] == 1);
+}
+
+@("Delete: Given {3,1,2} as [3,1,2,0] with last=2, delete 3 must result in {2,1} as [2,1,0,-1]")
+unittest
+{
+    ASet set;
+    New(set, 3);
+    Insert(set, 3);
+    Insert(set, 1);
+    Insert(set, 2);
+
+    Delete(set, 3);
+    
+    assert(In(set, 0) == false);
+    assert(In(set, 1) == true);
+    assert(In(set, 2) == true);
+    assert(In(set, 3) == false);
+
+    assert(set.List.Elem[0] == 2);
+    assert(set.List.Elem[1] == 1);
+}
+
+@("Delete: Given {4,1,3} as [4,1,3,2,0] with last=2, delete 4 must result in {3,1} as [3,1,-1,0,-1]")
+unittest
+{
+    ASet set;
+    New(set, 4);
+    Insert(set, 4);
+    Insert(set, 1);
+    Insert(set, 3);
+
+    Delete(set, 4);
+    
+    assert(In(set, 0) == false);
+    assert(In(set, 1) == true);
+    assert(In(set, 2) == false);
+    assert(In(set, 3) == true);
+    assert(In(set, 4) == false);
+
+    assert(set.List.Elem[0] == 3);
+    assert(set.List.Elem[1] == 1);
+}
+
+@("Insert elements continuously increasing by 1")
+unittest
+{
+    ASet set;
+    const elemCount = 10;
+    New(set, elemCount);
+
+    for(int j = firstIndex; j <= set.Max; ++j) {
+        Insert(set, j);
+    }
+
+    assert(set.List.Last == elemCount);
+    for(int j = firstIndex; j <= set.List.Last; ++j) {
+        assert(In(set, j));
+        assert(set.List.Elem[j] == j);
+    }
+}
+
+@("Insert elements continuously increasing, even only")
+unittest
+{
+    import std.conv : to;
+
+    ASet set;
+    const elemCount = 11;
+    New(set, elemCount);
+
+    for(int j = firstIndex; j <= set.Max; j=j+2) {
+        Insert(set, j);
+    }
+
+    assert(set.List.Last == elemCount/2);
+    for(int j = firstIndex; j <= set.List.Last; ++j) {
+        assert(In(set, j*2), "failed for element " ~ to!string(j*2));
+        assert(!In(set, j*2+1), "failed for element " ~ to!string(j*2+1));
+        assert(In(set, set.List.Elem[j]), "failed for element " ~ to!string(j));
+    }
+}
+
+@("Insert elements continuously decreasing by 1")
+unittest
+{
+    import std.conv : to;
+
+    ASet set;
+    const elemCount = 10;
+    New(set, elemCount);
+
+    for(int j = set.Max; j >= firstIndex; --j) {
+        Insert(set, j);
+    }
+
+    assert(set.List.Last == elemCount);
+    for(int j = firstIndex; j <= set.List.Last; ++j) {
+        assert(In(set, j), "failed for element " ~ to!string(j*2));
+        assert(In(set, set.List.Elem[j]), "failed for element " ~ to!string(j));
+    }
+}
+
+
+
+@("Delete elements continuously increasing by 1")
+unittest
+{
+    import std.conv : to;
+
+    ASet set;
+    const elemCount = 10;
+    New(set, elemCount);
+
+    for(int j = firstIndex; j <= set.Max; ++j) {
+        Insert(set, j);
+    }
+
+    for(int j = firstIndex; j <= set.Max; ++j) {
+        Delete(set, j);
+        for(int k = j+1; k <= set.Max; k++) {
+            assert(In(set, k), "In(set, " ~ to!string(k) ~ ") unexectedly");
+        }
+    }
+
+    assert(IsEmpty(set), "set is unexpectedly not empty");
+    assert(set.List.Last == -1, "List.Last is unexpectedly not -1");
+
+    for(int j = firstIndex; j < set.Max; ++j) {
+        assert(set.List.Elem[j] == noelem, "List.Elem[" ~ to!string(j) ~ "] is not noelem");
+    }
+}
+
+
+@("Delete elements continuously decreasing by 1")
+unittest
+{
+    import std.conv : to;
+
+    ASet set;
+    const elemCount = 10;
+    New(set, elemCount);
+
+    for(int j = firstIndex; j <= set.Max; ++j) {
+        Insert(set, j);
+    }
+
+    for(int j = set.Max; j >= firstIndex; --j) {
+        Delete(set, j);
+        for(int k = firstIndex; k < j; k++) {
+            assert(In(set, k), "failed for element " ~ to!string(k));
+            assert(In(set, set.List.Elem[k]), "failed for element " ~ to!string(k));
+        }
+    }
+
+    assert(IsEmpty(set), "set is unexpectedly not empty");
+    assert(set.List.Last == -1, "List.Last is unexpectedly not 0");
+
+    for(int j = firstIndex; j < set.Max; ++j) {
+        assert(set.List.Elem[j] == noelem, "List.Elem[" ~ to!string(j) ~ "] is not noelem");
     }
 }

--- a/src/soag/eSOAGOptimizer.d
+++ b/src/soag/eSOAGOptimizer.d
@@ -567,25 +567,28 @@ void Optimize()
     StackVar = firstStackVar - 1;
     for (S = SOAG.firstSym; S <= SOAG.NextSym - 1; ++S)
     {
-        for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
+        if (Sets.In(EAG.All, S))
         {
-            A = AP - SOAG.Sym[S].AffPos.Beg;
-            if (!Sets.In(EAG.Pred, S) || SOAG.IsSynthesized(S, A))
+            for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
             {
-                disjoint = true;
-                admissible = true;
-                InitVDSandVS(S, A);
-                CompleteInitVDS;
-                CheckStorageType(S, A);
-                if (disjoint)
+                A = AP - SOAG.Sym[S].AffPos.Beg;
+                if (!Sets.In(EAG.Pred, S) || SOAG.IsSynthesized(S, A))
                 {
-                    ++GlobalVar;
-                    SOAG.StorageName[AP] = -GlobalVar;
-                }
-                else if (admissible)
-                {
-                    ++StackVar;
-                    SOAG.StorageName[AP] = StackVar;
+                    disjoint = true;
+                    admissible = true;
+                    InitVDSandVS(S, A);
+                    CompleteInitVDS;
+                    CheckStorageType(S, A);
+                    if (disjoint)
+                    {
+                        ++GlobalVar;
+                        SOAG.StorageName[AP] = -GlobalVar;
+                    }
+                    else if (admissible)
+                    {
+                        ++StackVar;
+                        SOAG.StorageName[AP] = StackVar;
+                    }
                 }
             }
         }

--- a/src/soag/eSOAGProtocol.d
+++ b/src/soag/eSOAGProtocol.d
@@ -438,12 +438,12 @@ void WriteAffPos(int SymInd)
 void WriteSym(int S)
 {
     IO.WriteText(Out, "Symbol ");
-    EAG.WriteHNont(Out, SOAG.SymOcc[SOAG.Sym[S].FirstOcc].SymInd);
-    IO.WriteText(Out, ": \nFirstOcc: ");
+    EAG.WriteHNont(Out, S);
+    IO.WriteText(Out, ": \n  FirstOcc: ");
     IO.WriteInt(Out, SOAG.Sym[S].FirstOcc);
     IO.WriteLn(Out);
     WriteAffPos(S);
-    IO.WriteString(Out, "MaxPart: ");
+    IO.WriteString(Out, "  MaxPart: ");
     IO.WriteInt(Out, SOAG.Sym[S].MaxPart);
     IO.WriteLn(Out);
     IO.Update(Out);

--- a/src/soag/eSOAGVisitSeq.d
+++ b/src/soag/eSOAGVisitSeq.d
@@ -28,12 +28,15 @@ void ComputeVisitNo()
     int PartNum;
     for (S = SOAG.firstSym; S <= SOAG.NextSym - 1; ++S)
     {
-        MaxPart = DIV(SOAG.Sym[S].MaxPart + 1, 2).to!int;
-        SOAG.Sym[S].MaxPart = MaxPart;
-        for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
+        if (Sets.In(EAG.All, S))
         {
-            PartNum = DIV(SOAG.PartNum[AP] + 1, 2).to!int;
-            SOAG.PartNum[AP] = MaxPart - PartNum + 1;
+            MaxPart = DIV(SOAG.Sym[S].MaxPart + 1, 2).to!int;
+            SOAG.Sym[S].MaxPart = MaxPart;
+            for (AP = SOAG.Sym[S].AffPos.Beg; AP <= SOAG.Sym[S].AffPos.End; ++AP)
+            {
+                PartNum = DIV(SOAG.PartNum[AP] + 1, 2).to!int;
+                SOAG.PartNum[AP] = MaxPart - PartNum + 1;
+            }
         }
     }
 }

--- a/test/soag.d
+++ b/test/soag.d
@@ -38,9 +38,7 @@ unittest
     run("./epsilon --soag --space example/w-w.eag")
         .shouldMatch("Grammar is SOEAG");
     run("echo a b a b c a b a b | ./S")
-        .shouldMatch("^a b a b $")
-        .assertThrown!AssertError;
-    writeln("    FAILED");
+        .shouldMatch("^a b a b $");
 }
 
 @("compile w-w-soag.eag as SOAG and run compiler")
@@ -94,9 +92,7 @@ unittest
     run("./epsilon example/count4.eag")
         .shouldMatch("Grammar is SOEAG");
     run("echo a a a | ./S")
-        .shouldMatch("^3$")
-        .assertThrown!AssertError;
-    writeln("    FAILED");
+        .shouldMatch("^3$");
 }
 
 @("compile count5.eag as SOAG and run compiler")
@@ -131,7 +127,7 @@ unittest
 {
     run("./epsilon --soag example/single-sweep.eag")
         .shouldMatch("Grammar is SOEAG");
-        run!"cd %s && echo a b c d e | ./S"(directory)
+        run("echo a b c d e | ./S")
             .shouldMatch("^$");
 }
 

--- a/test/soag.d
+++ b/test/soag.d
@@ -130,9 +130,9 @@ unittest
 unittest
 {
     run("./epsilon --soag example/single-sweep.eag")
-        .shouldMatch("Grammar is SOEAG")
-        .assertThrown!AssertError;
-    writeln("    FAILED");
+        .shouldMatch("Grammar is SOEAG");
+        run!"cd %s && echo a b c d e | ./S"(directory)
+            .shouldMatch("^$");
 }
 
 @("compile single-sweep.eag as SOAG without optimization and run compiler")


### PR DESCRIPTION
As agreed with @linkrope offline, the fixes from PRs #6 and #3 has been redone on branch 0.2.1 to get the corrected ASets implementation preserved in an explicit version branch while stepping forward at master, replacing it by in this context similar efficient D set implementation.
